### PR TITLE
add subscription and support pages

### DIFF
--- a/account/subscription.mdx
+++ b/account/subscription.mdx
@@ -1,0 +1,25 @@
+---
+title: 'Subscription'
+description: 'How billing works for your mrge subscription.'
+---
+
+Your mrge subscription cost is determined by the number of developer seats you choose to activate. Each active seat corresponds to a unique GitHub user within your organization.
+
+- **Seat-based billing:** You are billed based on the number of _active_ seats you assign to your team members (GitHub users).
+- **Flexible seat management:** You can manage seat assignments at any time, both during your free trial and after it ends.
+- **Customizable checkout:** When you purchase a subscription, you select the exact number of seats you need.
+- **Subscription management:** Seat assignments and active seats can be viewed and managed through the subscription tab in your settings: [https://www.mrge.io/settings?tab=subscription](https://www.mrge.io/settings?tab=subscription)
+
+### Automatic seat assignment for new developers
+
+You can choose to automatically assign seats to new developers who join your linked GitHub organization. This setting can be toggled in your subscription settings.
+
+When enabled, any new developer joining your GitHub organization will automatically be assigned a mrge seat and included in your billing. Conversely, if a developer leaves your organization, their seat will be automatically removed, and you will no longer be billed for them.
+
+- **Compatibility with manual selection:** This feature works alongside manual seat selection. For example, if you have manually assigned seats to 3 out of 10 developers in your organization and then enable the "Assign seats to new developers" toggle, when an 11th developer joins the organization, they will automatically receive a mrge seat, bringing your total assigned seats to 4.
+
+## Free trial
+
+During the free trial period, you can assign as many developer seats as you like to evaluate mrge with your team. Billing will only begin after the trial ends and is based on the number of seats you select at checkout.
+
+If you have any further questions about billing, please contact support.

--- a/account/subscription.mdx
+++ b/account/subscription.mdx
@@ -22,4 +22,4 @@ When enabled, any new developer joining your GitHub organization will automatica
 
 During the free trial period, you can assign as many developer seats as you like to evaluate mrge with your team. Billing will only begin after the trial ends and is based on the number of seats you select at checkout.
 
-If you have any further questions about billing, please contact support.
+If you have any further questions about billing, please [contact support](mailto:contact@mrge.io).

--- a/account/support.mdx
+++ b/account/support.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Support'
+---
+
+If you have any questions, require help, or want to share feedback, please reach out to [contact@mrge.io](mailto:contact@mrge.io).

--- a/code-review-platform/slack.mdx
+++ b/code-review-platform/slack.mdx
@@ -42,3 +42,6 @@ To disconnect Slack from mrge:
 
 Once disconnected, you will stop receiving mrge notifications in Slack.
 
+---
+
+_For details on how we handle your data with this integration, please see our [privacy policy](https://www.mrge.io/privacy)._

--- a/docs.json
+++ b/docs.json
@@ -44,7 +44,9 @@
               "code-review-platform/comment-navbar",
               "code-review-platform/desktop-app",
               "code-review-platform/command-bar",
-              "code-review-platform/slack"
+              "code-review-platform/slack",
+              "account/subscription",
+              "account/support"
             ]
           }
         ]


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added new subscription and support pages to the documentation to explain billing and provide contact information.

- **New Features**
  - Subscription page covers seat-based billing, seat management, and free trial details.
  - Support page gives a contact email for help and feedback.

<!-- End of auto-generated description by mrge. -->

